### PR TITLE
修复下拉加载更多bug

### DIFF
--- a/src/components/MainSec.vue
+++ b/src/components/MainSec.vue
@@ -34,8 +34,8 @@ export default {
         scrollMethod() {
             const sumH = document.body.scrollHeight;
             const viewH = document.documentElement.clientHeight;
-            const scrollH = document.body.scrollTop;
-            if (viewH + scrollH === sumH) {
+            const scrollH = document.documentElement.scrollTop;
+            if (viewH + scrollH >= sumH) {
                 this.getData();
             }
         },

--- a/src/components/MainSec.vue
+++ b/src/components/MainSec.vue
@@ -35,7 +35,7 @@ export default {
             const sumH = document.body.scrollHeight;
             const viewH = document.documentElement.clientHeight;
             const scrollH = document.documentElement.scrollTop;
-            if (viewH + scrollH >= sumH) {
+            if (viewH + scrollH >== sumH) {
                 this.getData();
             }
         },


### PR DESCRIPTION
1. 在我的浏览器中(chrom62) `document.body.scrollTop`的值一直为0,
2. `===`会导致值一直取不准,所以加载也不成功,要不改为`>=`?